### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'six',
         'unicodecsv',
         'pyyaml',
-        'datapackage',
+        'datapackage<1.0',
         'bs4',
         'markdown',
         'ckanapi',


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.